### PR TITLE
chore: add .gitignore for node & Next.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node
+node_modules
+npm-debug.log*
+yarn-error.log*
+package-lock.json
+
+# Next.js / Vercel
+.next
+.out
+.vercel
+.DS_Store
+
+# Env
+.env


### PR DESCRIPTION
## Summary
- ignore Node.js dependencies and logs
- ignore Next.js build output and Vercel configuration
- ignore local environment files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689081c4603083269ce4e97353c15510