### PR TITLE
frontend: minimal Next.js 14 + Tailwind skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node
+node_modules
+npm-debug.log*
+yarn-error.log*
+package-lock.json
+
+# Next.js / Vercel
+.next
+.out
+.vercel
+.DS_Store
+
+# Env
+.env

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <h1 className="text-2xl font-bold">LeakIntel Frontend Works!</h1>
+    </main>
+  );
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "leak-intel-frontend",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.3"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: { tailwindcss: {}, autoprefixer: {} },
+}

--- a/frontend/public/mock/devices.json
+++ b/frontend/public/mock/devices.json
@@ -1,0 +1,3 @@
+[
+  { "id": "UXD25003", "brand": "KEF", "model": "Coda W", "reg_source": "fcc", "first_seen": "2025-07-17" }
+]

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  content: ["./app/**/*.{ts,tsx}"],
+  theme: { extend: {} },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "noEmit": true,
+    "esModuleInterop": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold basic Next.js 14 frontend with React 18 and common scripts
- configure TypeScript, Tailwind, PostCSS and Next.js runtime settings
- add starter page and mock device data

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test --prefix frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689081c4603083269ce4e97353c15510