### PR TITLE
bot: add Slack app manifest & Bolt skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # leak_intel
 
 This is for testing purpose only.
+
+## Slack Bot
+
+### Install
+1. Create a new Slack App using the manifest at `bot/manifest.yml`.
+2. Install dependencies:
+   ```bash
+   pip install slack_bolt
+   ```
+3. Set the following environment variables with your app credentials:
+   * `SLACK_BOT_TOKEN`
+   * `SLACK_APP_TOKEN`
+4. Run the bot:
+   ```bash
+   python bot/app.py
+   ```
+

--- a/bot/app.py
+++ b/bot/app.py
@@ -1,0 +1,16 @@
+import os
+import re
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+app = App(token=os.environ.get("SLACK_BOT_TOKEN"))
+
+@app.message(re.compile(".*"))
+def echo_message(message, say):
+    text = message.get("text", "")
+    say(text)
+
+if __name__ == "__main__":
+    handler = SocketModeHandler(app, os.environ.get("SLACK_APP_TOKEN"))
+    handler.start()
+

--- a/bot/manifest.yml
+++ b/bot/manifest.yml
@@ -1,0 +1,15 @@
+display_information:
+  name: Leak Intel Bot
+features:
+  bot_user:
+    display_name: Leak Intel Bot
+oauth_config:
+  scopes:
+    bot:
+      - chat:write
+      - commands
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false
+


### PR DESCRIPTION
## Summary
- add Slack app manifest with chat:write and commands scopes
- implement minimal Slack Bolt echo listener
- document Slack bot installation in README

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile bot/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689083d5b77083269c1a75df648e6cb2