### PR TITLE
backend: add FastAPI v0 skeleton + local run docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,24 @@
 
 This is for testing purpose only.
 
+## Local dev
+
+```bash
+# backend (FastAPI)
+cd backend && poetry install && poetry run uvicorn app.main:app --reload
+
+# frontend (Next.js)
+cd frontend && npm install && npm run dev
+```
 
 ## Quick start
 
 ```bash
 # frontend
-cd frontend && npm run dev
+cd frontend && npm install && npm run dev
 
 # backend
-poetry install
-uvicorn backend.main:app --reload
+cd backend && poetry install && poetry run uvicorn app.main:app --reload
 
 # crawler (mock)
 scrapy crawl fcc > data.json

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,17 @@
+# LeakIntel FastAPI backend
+
+## Quick start (local)
+
+```bash
+# in repo root
+cd backend
+
+# install Poetry & deps
+pip install poetry
+poetry install
+
+# run dev server
+poetry run uvicorn app.main:app --reload
+```
+
+Visit http://127.0.0.1:8000/docs for Swagger UI.

--- a/backend/app/devices_mock.json
+++ b/backend/app/devices_mock.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "UXD25003",
+    "brand": "KEF",
+    "model": "Coda W",
+    "reg_source": "fcc",
+    "first_seen": "2025-07-17",
+    "ai": {
+      "est_release_date": "2025-12-20",
+      "est_price_range": "500-800"
+    },
+    "attributes": { "power": "200W" }
+  }
+]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, Query
+from pydantic import BaseModel
+from pathlib import Path
+import json
+
+app = FastAPI(title="LeakIntel API v0")
+
+# --- mock data ---------------------------------
+DATA_PATH = Path(__file__).parent / "devices_mock.json"
+MOCK = json.loads(DATA_PATH.read_text())
+
+class Device(BaseModel):
+    id: str
+    brand: str
+    model: str
+    reg_source: str
+    first_seen: str | None = None
+    ai: dict | None = None
+    attributes: dict | None = None
+
+@app.get("/v0/devices", response_model=list[Device])
+def list_devices(source: str | None = Query(None, description="Comma-separated reg_source filter")):
+    if source:
+        allowed = set(source.split(","))
+        return [d for d in MOCK if d["reg_source"] in allowed]
+    return MOCK
+
+@app.get("/v0/devices/{device_id}", response_model=Device)
+def get_device(device_id: str):
+    for d in MOCK:
+        if d["id"] == device_id:
+            return d
+    return {"detail": "Not found"}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "leak_intel_backend"
+version = "0.0.1"
+description = "FastAPI skeleton for Leak Intelligence Platform"
+authors = ["LeakIntel Contributors"]
+license = "MIT"
+readme = "README.md"
+packages = [{ include = "app", from = "." }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.111.0"
+uvicorn = { extras = ["standard"], version = "^0.29.0" }
+pydantic = "^2.6.4"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- add `backend` service with FastAPI, Pydantic, and Uvicorn configured via Poetry
- include mock device data and two basic `/v0/devices` endpoints
- document backend usage and local dev commands in backend and root READMEs

## Testing
- `python -m py_compile backend/app/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68908e51b4088326a8b7766a74bb5c6c